### PR TITLE
chore: release v0.0.3

### DIFF
--- a/src/ggl_cli/CHANGELOG.md
+++ b/src/ggl_cli/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.3](https://github.com/ocasazza/graph_generation_language/releases/tag/ggl_cli-v0.0.3) - 2025-07-13
+
+### Other
+
+- ...compat
+- more build fixes
+- fmt and rename

--- a/src/ggl_client/CHANGELOG.md
+++ b/src/ggl_client/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.3](https://github.com/ocasazza/graph_generation_language/releases/tag/ggl_client-v0.0.3) - 2025-07-13
+
+### Other
+
+- more build fixes
+- fmt and rename

--- a/src/ggl_wasm/CHANGELOG.md
+++ b/src/ggl_wasm/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.3](https://github.com/ocasazza/graph_generation_language/releases/tag/ggl_wasm-v0.0.3) - 2025-07-13
+
+### Other
+
+- ...compat
+- more build fixes
+- fmt and rename


### PR DESCRIPTION



## 🤖 New release

* `ggl_cli`: 0.0.3
* `ggl_wasm`: 0.0.3
* `ggl_client`: 0.0.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `ggl_cli`

<blockquote>

## [0.0.3](https://github.com/ocasazza/graph_generation_language/releases/tag/ggl_cli-v0.0.3) - 2025-07-13

### Other

- ...compat
- more build fixes
- fmt and rename
</blockquote>

## `ggl_wasm`

<blockquote>

## [0.0.3](https://github.com/ocasazza/graph_generation_language/releases/tag/ggl_wasm-v0.0.3) - 2025-07-13

### Other

- ...compat
- more build fixes
- fmt and rename
</blockquote>

## `ggl_client`

<blockquote>

## [0.0.3](https://github.com/ocasazza/graph_generation_language/releases/tag/ggl_client-v0.0.3) - 2025-07-13

### Other

- more build fixes
- fmt and rename
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).