### PR TITLE
chore: release v0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
 dependencies = [
  "anstream",
  "anstyle",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "ggl_cli"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "clap",
  "graph_generation_language",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "ggl_client"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "console_error_panic_hook",
  "gloo 0.11.0",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "ggl_wasm"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "console_error_panic_hook",
  "graph_generation_language",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "graph_generation_language"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "fastrand",
  "pest",
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1063,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
  "syn 2.0.104",
@@ -1142,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustversion"
@@ -1202,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -1310,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "io-uring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Olive Casazza <olive.casazza@schrodinger.com>"]
 edition = "2021"
-version = "0.0.4"
+version = "0.0.5"
 license = "MIT"
 repository = "https://github.com/ocasazza/graph_generation_language"
 homepage = "https://ocasazza.github.io/graph_generation_language/"

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -10,7 +10,7 @@ description = "Command-line interface for the Graph Generation Language (GGL)"
 name = "ggl"
 
 [dependencies]
-graph_generation_language = { path = "../lib", version = "0.0.4"  }
+graph_generation_language = { path = "../lib", version = "0.0.5" }
 clap = { version = "4.3.14", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/client/CHANGELOG.md
+++ b/src/client/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.5](https://github.com/ocasazza/graph_generation_language/compare/ggl_client-v0.0.4...ggl_client-v0.0.5) - 2025-08-01
+
+### Other
+
+- layout
+- some demo fixes
+
 ## [0.0.3](https://github.com/ocasazza/graph_generation_language/releases/tag/ggl_client-v0.0.3) - 2025-07-13
 
 ### Other

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 description = "Frontend client for graph_generation_language"
 
 [dependencies]
-graph_generation_language = { path = "../lib", version = "0.0.4"  }
+graph_generation_language = { path = "../lib", version = "0.0.5" }
 console_error_panic_hook = "0.1.7"
 wasm-bindgen = "0.2.100"
 web-sys = { version = "0.3.77", features = ["Window", "Document", "HtmlElement", "Text", "console"] }

--- a/src/lib/CHANGELOG.md
+++ b/src/lib/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.5](https://github.com/ocasazza/graph_generation_language/compare/graph_generation_language-v0.0.4...graph_generation_language-v0.0.5) - 2025-08-01
+
+### Other
+
+- Update readme.md
+- changelog

--- a/src/wasm/Cargo.toml
+++ b/src/wasm/Cargo.toml
@@ -9,7 +9,7 @@ description = "WASM bindings for graph_generation_language"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-graph_generation_language = { path = "../lib", version = "0.0.4"  }
+graph_generation_language = { path = "../lib", version = "0.0.5" }
 console_error_panic_hook = "0.1.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"


### PR DESCRIPTION



## 🤖 New release

* `graph_generation_language`: 0.0.4 -> 0.0.5 (✓ API compatible changes)
* `ggl_cli`: 0.0.4 -> 0.0.5
* `ggl_wasm`: 0.0.4 -> 0.0.5
* `ggl_client`: 0.0.4 -> 0.0.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `graph_generation_language`

<blockquote>

## [0.0.5](https://github.com/ocasazza/graph_generation_language/compare/graph_generation_language-v0.0.4...graph_generation_language-v0.0.5) - 2025-08-01

### Other

- Update readme.md
- changelog
</blockquote>

## `ggl_cli`

<blockquote>

## [0.0.3](https://github.com/ocasazza/graph_generation_language/releases/tag/ggl_cli-v0.0.3) - 2025-07-13

### Other

- ...compat
- more build fixes
- fmt and rename
</blockquote>

## `ggl_wasm`

<blockquote>

## [0.0.3](https://github.com/ocasazza/graph_generation_language/releases/tag/ggl_wasm-v0.0.3) - 2025-07-13

### Other

- ...compat
- more build fixes
- fmt and rename
</blockquote>

## `ggl_client`

<blockquote>

## [0.0.5](https://github.com/ocasazza/graph_generation_language/compare/ggl_client-v0.0.4...ggl_client-v0.0.5) - 2025-08-01

### Other

- layout
- some demo fixes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).